### PR TITLE
#169745274 Users can update record details with application

### DIFF
--- a/server/v1/api/controllers/updateComment.js
+++ b/server/v1/api/controllers/updateComment.js
@@ -1,0 +1,55 @@
+import dotenv from 'dotenv';
+import jwt from 'jsonwebtoken';
+import impData from '../models/DB';
+import impDataFromToken from '../helpers/token';
+
+dotenv.config();
+const updateSingleRecords = {
+  updateOneRecordsComment(req, res) {
+    const receive_token_from_header = req.headers.authorization;
+    const decoded_token_in_the_way_to_obtain_user_details = jwt.verify(receive_token_from_header, process.env.SECRET_KEY);
+    const { createdBy, title, type, latitude, longitude, comment } = req.body;
+
+    const recordId = parseInt(req.params.redflagid);
+    const data = impData.fetchOneRecord(recordId);
+
+    if (!recordId) {
+      return res.status(404).json({ status: 404, message: `Hey ${decoded_token_in_the_way_to_obtain_user_details.username} insert record id ` });
+    }
+
+    if (!data) {
+      return res.status(404).json({ status: 404, message: `Hey ${decoded_token_in_the_way_to_obtain_user_details.username} this record with id ${recordId} is not found ` });
+    }
+    if (data.userId !== decoded_token_in_the_way_to_obtain_user_details.id) {
+      return res.status(400).json({ status: 400, message: `Hey ${decoded_token_in_the_way_to_obtain_user_details.username} you are not owner of this record with id ${recordId} ` });
+    }
+
+    let imgs;
+    let vids;
+    if (req.files) {
+      if (req.files.images) {
+        const imgsPath = req.files.images.map(({ path }) => path);
+        imgs = imgsPath.join(',  ');
+      }
+      if (req.files.videos) {
+        const vidsPath = req.files.videos.map(({ path }) => path);
+        vids = vidsPath.join(',  ');
+      }
+    }
+
+    const readyDatas = {
+      userId: decoded_token_in_the_way_to_obtain_user_details.id,
+      createdBy: createdBy,
+      title: title,
+      type: type,
+      latitude: latitude,
+      longitude: longitude,
+      images: imgs,
+      videos: vids,
+      comment: comment,
+    };
+    const updatedRecord = impData.updateComment(parseInt(req.params.redflagid), readyDatas);
+    return res.status(200).json({ status: 200, message: `Hey ${decoded_token_in_the_way_to_obtain_user_details.username} !! Your record with id ${recordId} was updated Successfully `, updateRecord: updatedRecord });
+  },
+};
+export default updateSingleRecords;


### PR DESCRIPTION
## What does this PR do?

- Created update record details back-end of application for users.
- caught all mistakes that can happen while the user wants to update record details.
- return all details of updated record and message when record details updated successfully.


## Description of Task to be completed?

- During in the completion of this work I have created an update record details back-end of an application for users. 
  and this update record details back-end can catch all mistakes that can occur while the user wants to update record details of users with application.

- Also when record details updated successfully, a user will get some data like event status, event message and updated record details.


## How should this be manually tested?

- The way this will be tested, it will occur when users visited update record details endpoint.
- Also, could be tested when users need to update record details with application.


## Any background context you want to provide?

- The context was all about nodejs with libraries.


## What are the relevant pivotal tracker stories?
- [Feature: Users can update record details with application](https://www.pivotaltracker.com/story/show/169745274)

Screenshots (if appropriate)

![updaterecordcomment](https://user-images.githubusercontent.com/38179232/68987760-a3a4d900-0835-11ea-89b8-823165c8cce5.PNG)
