### PR TITLE
#169745451 Admin can change status of record with application

### DIFF
--- a/server/v1/api/controllers/changesStatus.js
+++ b/server/v1/api/controllers/changesStatus.js
@@ -1,0 +1,25 @@
+import dotenv from 'dotenv';
+import jwt from 'jsonwebtoken';
+import impData from '../models/DB';
+import impDataFromToken from '../helpers/token';
+
+dotenv.config();
+const changeStatusOfSingleRecords = {
+  adminchangeStatusOfOneRecord(req, res) {
+    const receive_token_from_header = req.headers.authorization;
+    const decoded_token_in_the_way_to_obtain_user_details = jwt.verify(receive_token_from_header, process.env.SECRET_KEY);
+
+    const recordId = parseInt(req.params.redflagid);
+    const data = impData.fetchOneRecord(recordId);
+
+    if (!recordId) {
+      return res.status(404).json({ status: 404, message: `Hey Admin ${decoded_token_in_the_way_to_obtain_user_details.username} insert record id ` });
+    }
+    if (!data) {
+      return res.status(404).json({ status: 404, message: `Hey Admin ${decoded_token_in_the_way_to_obtain_user_details.username} this record with id ${recordId} is not found ` });
+    }
+    const updatedRecord = impData.changeStatus(parseInt(req.params.redflagid), req.body);
+    return res.status(200).json({ status: 200, message: `Hey Admin ${decoded_token_in_the_way_to_obtain_user_details.username} !! You are changed status of this record with id ${recordId} Successfully `, changedRecord: updatedRecord });
+  },
+};
+export default changeStatusOfSingleRecords;


### PR DESCRIPTION
## What does this PR do?

- Created change status back-end of application for admin.
- caught all mistakes that can happen while the admin wants to change status.
- return message when record status changed successfully.


## Description of Task to be completed?

- During in the completion of this work I have created change status record back-end of an application for admin.
  and this change status back-end can catch all mistakes that can occur while admin wants to change status with application.

- Also when record status changed successfully, an admin will get some data like event status, event message.


## How should this be manually tested?

- The way this will be tested, it will occur when admin visited change status endpoint.
- Also, could be tested when an admin needs to change the status of record with the application.


## Any background context you want to provide?

- The context was all about nodejs with libraries.


## What are the relevant pivotal tracker stories?
- [Feature: Admin can change the status of record with application](https://www.pivotaltracker.com/story/show/169745451)

Screenshots (if appropriate)

![changeStatus](https://user-images.githubusercontent.com/38179232/68988041-13b55e00-083a-11ea-87c9-88d2c0381c29.PNG)
