### PR TITLE
#170105637 As user, should be able to delete record

### DIFF
--- a/server/v2/api/controllers/recordsContollers.js
+++ b/server/v2/api/controllers/recordsContollers.js
@@ -103,6 +103,26 @@ class Records {
     return res.status(200).json({ status: 200, message: `Hey ${req.attachedWithInfo.username} !! Your record with id ${(parseInt(req.params.redflagid))} was updated Successfully `, data: updateRecord });
   }
 
+  async updateLocation(req, res) {
+    const userRecData = await impData.fetchOneRecord((parseInt(req.params.redflagid)));
+    if (!(parseInt(req.params.redflagid))) {
+      return res.status(404).json({ status: 404, message: `Hey ${req.attachedWithInfo.username} insert record id ` });
+    }
+    if (userRecData.length === 0) {
+      return res.status(404).json({ status: 404, message: `Hey ${req.attachedWithInfo.username} this record with id ${(parseInt(req.params.redflagid))} is not found ` });
+    }
+    if (userRecData[0].userid !== req.attachedWithInfo.id) {
+      return res.status(400).json({ status: 400, message: `Hey ${req.attachedWithInfo.username} you are not owner of this record with id ${(parseInt(req.params.redflagid))} ` });
+    }
+    const updateLocation = {
+      latitude: req.body.latitude || userRecData[0].latitude,
+      longitude: req.body.longitude || userRecData[0].longitude,
+    };
+    const updatRecord = await impData.updateLocation(updateLocation, parseInt(req.params.redflagid));
+    return res.status(200).json({ status: 200, message: `Hey ${req.attachedWithInfo.username} !! Your record with id ${(parseInt(req.params.redflagid))} was updated Successfully `, data: updatRecord });
+  }
+
+
 
 }
 const expRecords = new Records();

--- a/server/v2/api/controllers/recordsContollers.js
+++ b/server/v2/api/controllers/recordsContollers.js
@@ -122,7 +122,20 @@ class Records {
     return res.status(200).json({ status: 200, message: `Hey ${req.attachedWithInfo.username} !! Your record with id ${(parseInt(req.params.redflagid))} was updated Successfully `, data: updatRecord });
   }
 
-
+  async destroyRecord(req, res) {
+    const getData = await impData.fetchOneRecord((parseInt(req.params.redflagids)));
+    if (!(parseInt(req.params.redflagids))) {
+      return res.status(404).json({ status: 404, message: `Hey ${req.attachedWithInfo.username} insert record id ` });
+    }
+    if (getData.length === 0) {
+      return res.status(404).json({ status: 404, message: `Hey ${req.attachedWithInfo.username} this record with id ${(parseInt(req.params.redflagids))} is not found ` });
+    }
+    if (getData[0].userid !== req.attachedWithInfo.id) {
+      return res.status(400).json({ status: 400, message: `Hey ${req.attachedWithInfo.username} you are not owner of this record with id ${(parseInt(req.params.redflagids))} ` });
+    }
+    await impData.deleteRecord((parseInt(req.params.redflagids)));
+    return res.status(200).json({ status: 200, message: `Hey ${req.attachedWithInfo.username} !! this record with id ${(parseInt(req.params.redflagids))} was deleted Successfully ` });
+  }
 
 }
 const expRecords = new Records();

--- a/server/v2/api/routes/recordsRoute.js
+++ b/server/v2/api/routes/recordsRoute.js
@@ -9,6 +9,7 @@ recordApp
   .post('/red-flags', verfUser, fileImp.allFile, imprecordRoute.createRecord)
   .get('/red-flags', verfUser, imprecordRoute.findAllRecord)
   .get('/red-flags/:redflagid', verfUser, imprecordRoute.findRecord)
-  .patch('/red-flags/:redflagid/comment', verfUser, fileImp.allFile, imprecordRoute.updateComment);
+  .patch('/red-flags/:redflagid/comment', verfUser, fileImp.allFile, imprecordRoute.updateComment)
+  .patch('/red-flags/:redflagid/location', verfUser, imprecordRoute.updateLocation);
 
 export default recordApp;

--- a/server/v2/api/routes/recordsRoute.js
+++ b/server/v2/api/routes/recordsRoute.js
@@ -10,6 +10,7 @@ recordApp
   .get('/red-flags', verfUser, imprecordRoute.findAllRecord)
   .get('/red-flags/:redflagid', verfUser, imprecordRoute.findRecord)
   .patch('/red-flags/:redflagid/comment', verfUser, fileImp.allFile, imprecordRoute.updateComment)
-  .patch('/red-flags/:redflagid/location', verfUser, imprecordRoute.updateLocation);
+  .patch('/red-flags/:redflagid/location', verfUser, imprecordRoute.updateLocation)
+  .delete('/red-flags/:redflagids', verfUser, imprecordRoute.destroyRecord);
 
 export default recordApp;

--- a/test/vb/aMdeleteRecordTest.js
+++ b/test/vb/aMdeleteRecordTest.js
@@ -1,0 +1,73 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../../connection';
+import imptokelp from '../../server/v2/api/helpers/tokenHelper';
+
+chai.use(chaiHttp);
+const router = () => chai.request(app);
+describe('my Testing suite', () => {
+  const userToken = imptokelp.userCreatedToken;
+  it('user should be able to delete record ', (done) => {
+    const redflagids = 5;
+    router()
+      .delete(`/api/v2/red-flags/${redflagids}`)
+      .set('Authorization', userToken)
+      .end((error, response) => {
+        expect(response).to.have.status([200]);
+        expect(response.body).to.be.a('object');
+        expect(response.body).to.have.property('status');
+        expect(response.body.status).to.be.equal(200);
+        expect(response.body).to.have.property('message');
+        expect(response.body.message).to.be.a('string');
+        done(error);
+      });
+  });
+
+  it('users should not be able to delete record without recordId', (done) => {
+    const redflagids = 100;
+    router()
+      .delete(`/api/v2/red-flags/${redflagids}`)
+      .set('Authorization', userToken)
+      .end((error, response) => {
+        expect(response).to.have.status([404]);
+        expect(response.body).to.be.a('object');
+        expect(response.body).to.have.property('status');
+        expect(response.body.status).to.be.equal(404);
+        expect(response.body).to.have.property('message');
+        expect(response.body.message).to.be.a('string');
+        done(error);
+      });
+  });
+
+  it('user should not be able to delete record when used wrong recordId', (done) => {
+    const redflagids = 100;
+    router()
+      .delete(`/api/v2/red-flags/${redflagids}`)
+      .set('Authorization', userToken)
+      .end((error, response) => {
+        expect(response).to.have.status([404]);
+        expect(response.body).to.be.a('object');
+        expect(response.body).to.have.property('status');
+        expect(response.body.status).to.be.equal(404);
+        expect(response.body).to.have.property('message');
+        expect(response.body.message).to.be.a('string');
+        done(error);
+      });
+  });
+
+  it('user should not be able to delete record when he/she is not owner of a record', (done) => {
+    const redflagids = 3;
+    router()
+      .delete(`/api/v2/red-flags/${redflagids}`)
+      .set('Authorization', userToken)
+      .end((error, response) => {
+        expect(response).to.have.status([400]);
+        expect(response.body).to.be.a('object');
+        expect(response.body).to.have.property('status');
+        expect(response.body.status).to.be.equal(400);
+        expect(response.body).to.have.property('message');
+        expect(response.body.message).to.be.a('string');
+        done(error);
+      });
+  });
+});

--- a/test/vb/dacUpdateLocation.js
+++ b/test/vb/dacUpdateLocation.js
@@ -1,0 +1,97 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import impDB from './allTestDB';
+import app from '../../connection';
+import imptokelp from '../../server/v2/api/helpers/tokenHelper';
+
+chai.use(chaiHttp);
+const router = () => chai.request(app);
+describe('my Testing suite', () => {
+  const adminToken = imptokelp.adminCreatedToken;
+  const userToken = imptokelp.userCreatedToken;
+  it('user  should be able update location of his/her created record', (done) => {
+    const redflagid = 4;
+    router()
+      .patch(`/api/v2/red-flags/${redflagid}/location`)
+      .set('Authorization', userToken)
+      .send(impDB[17])
+      .end((error, response) => {
+        expect(response).to.have.status([200]);
+        expect(response.body).to.be.a('object');
+        expect(response.body).to.have.property('status');
+        expect(response.body.status).to.be.equal(200);
+        expect(response.body).to.have.property('message');
+        expect(response.body.message).to.be.a('string');
+        expect(response.body).to.have.property('data');
+        done(error);
+      });
+  });
+
+  it('users should not be able to update location of  record without recordId', (done) => {
+    const redflagid = 100;
+    router()
+      .patch(`/api/v2/red-flags/${redflagid}/location`)
+      .set('Authorization', userToken)
+      .end((error, response) => {
+        expect(response).to.have.status([404]);
+        expect(response.body).to.be.a('object');
+        expect(response.body).to.have.property('status');
+        expect(response.body.status).to.be.equal(404);
+        expect(response.body).to.have.property('message');
+        expect(response.body.message).to.be.a('string');
+        done(error);
+      });
+  });
+
+  it('user  should be able to skip update location of  his/her created record', (done) => {
+    const redflagid = 4;
+    router()
+      .patch(`/api/v2/red-flags/${redflagid}/location`)
+      .set('Authorization', userToken)
+      .send(impDB[0])
+      .end((error, response) => {
+        expect(response).to.have.status([200]);
+        expect(response.body).to.be.a('object');
+        expect(response.body).to.have.property('status');
+        expect(response.body.status).to.be.equal(200);
+        expect(response.body).to.have.property('message');
+        expect(response.body.message).to.be.a('string');
+        expect(response.body).to.have.property('data');
+        done(error);
+      });
+  });
+
+  it('user  should not be able update location of  his/her created record Location with wrong redflagId', (done) => {
+    const redflagid = 100;
+    router()
+      .patch(`/api/v2/red-flags/${redflagid}/location`)
+      .set('Authorization', userToken)
+      .send(impDB[17])
+      .end((error, response) => {
+        expect(response).to.have.status([404]);
+        expect(response.body).to.be.a('object');
+        expect(response.body).to.have.property('status');
+        expect(response.body.status).to.be.equal(404);
+        expect(response.body).to.have.property('message');
+        expect(response.body.message).to.be.a('string');
+        done(error);
+      });
+  });
+
+  it('user  should not be able update location of his/her created record Location of other user', (done) => {
+    const redflagid = 4;
+    router()
+      .patch(`/api/v2/red-flags/${redflagid}/location`)
+      .set('Authorization', adminToken)
+      .send(impDB[17])
+      .end((error, response) => {
+        expect(response).to.have.status([400]);
+        expect(response.body).to.be.a('object');
+        expect(response.body).to.have.property('status');
+        expect(response.body.status).to.be.equal(400);
+        expect(response.body).to.have.property('message');
+        expect(response.body.message).to.be.a('string');
+        done(error);
+      });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

- Created a `destroyRecord` endpoint.

## DESCRIPTION OF TASK TO BE COMPLETED?

During the completion of this work, a user could make a request to delete(api/v2/records/:red-flagId) route with broadcast application then a user should be able to use a recordId and given token to get authorized to delete that record with that recordId with broadcaster application.


## HOW SHOULD THIS BE MANUALLY TESTED?

####  The way this will be tested:

- Users should clone this repository into his/her machine.
- Users should run ```npm install``` command to install all required tools.
- Users should get start run ```npm run server``` command to start the server.
- Users should have to open postman which will be using to testing this single endpoint.
- Users should have to use this URL when tested local ```localhost:3000/api/v2/records/:red-flagId``` in postman and when a request runs perfect will get response in this format below:

## RESPONSE:
status code (200 Ok )
message (string)
data (object )

```
{
	"status":  200,
	"message":  "record deleted successfully   ", 
	"data":{[ ]}
	
}

```
## ANY BACKGROUND CONTEXT YOU  WANT TO PROVIDE?

- The context was all about NODEJS with LIBRARIES.

## What are the relevant pivotal tracker stories?
- [Feature:  As user, should be able to delete record](https://www.pivotaltracker.com/story/show/170105637)

#### Screenshots (if appropriate)

- User, delete record
![delete](https://user-images.githubusercontent.com/38179232/70157631-905f8d80-16be-11ea-9901-1da49a53f85d.PNG)








